### PR TITLE
Fix location pointer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ executes queries over the tree. It uses all available cores (two in
 the above example). The test lasts for 20 seconds. It populates the
 key-value store with `put` queries during first 10 seconds, and then
 issues `get` queries over the tree during the next 10 seconds. See
-`kvtest_rw1_seed` in `mttest.hh` for more details about the workload.
+`kvtest_rw1_seed` in `kvtest.hh` for more details about the workload.
 For a list of workloads, run `./mttest --help`.
 
 The output summarizes the throughput of each core. The `1/1 rw1/m` line says


### PR DESCRIPTION
This minor update fixes the location given for the kvtest_rw1_seed, et al. methods, which now seem to be situated in kvtest.hh rather than mttest.hh as was originally documented.
