### PR TITLE
Ignore configure script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /config.h
 /config.log
 /config.status
+/configure
 /msgpacktest
 /mtclient
 /mtd


### PR DESCRIPTION
Since df4d97c removed configure from version control, it seems like it should be gitignored too. #ocd