### PR TITLE
Fail bootstrapping when autoconf isn't installed.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/sh -e
 
 autoreconf -i
 


### PR DESCRIPTION
Currently, bootstrap.sh doesn't properly fail when autoconf isn't installed.

(I have real pull requests coming if the Apple Store Rochester ever manages to obtain a replacement logic board or I convince myself to continue developing on this piece of @#$% netbook.)