### PR TITLE
mtclient: measure latency of operations

### DIFF
--- a/testrunner.hh
+++ b/testrunner.hh
@@ -45,9 +45,13 @@ class testrunner : public testrunner_base {
     static testrunner* find(const lcdf::String& name) {
         return static_cast<testrunner*>(testrunner_base::find(name));
     }
-    virtual void run(TESTRUNNER_CLIENT_TYPE) = 0;
+  virtual void run(TESTRUNNER_CLIENT_TYPE) = 0;
+#ifdef TESTRUNNER_CLIENT_LATENCYTEST_TYPE
+  virtual void run_lat(TESTRUNNER_CLIENT_LATENCYTEST_TYPE) = 0;
+#endif
 };
 
+#ifndef TESTRUNNER_CLIENT_LATENCYTEST_TYPE
 #define MAKE_TESTRUNNER(name, text)                    \
     namespace {                                        \
     class testrunner_##name : public testrunner {      \
@@ -55,6 +59,16 @@ class testrunner : public testrunner_base {
         testrunner_##name() : testrunner(#name) {}     \
         void run(TESTRUNNER_CLIENT_TYPE client) { text; client.finish(); } \
     }; static testrunner_##name testrunner_##name##_instance; }
+#else
+#define MAKE_TESTRUNNER(name, text)                    \
+    namespace {                                        \
+    class testrunner_##name : public testrunner {      \
+    public:                                            \
+        testrunner_##name() : testrunner(#name) {}     \
+        void run(TESTRUNNER_CLIENT_TYPE client) { text; client.finish(); } \
+        void run_lat(TESTRUNNER_CLIENT_LATENCYTEST_TYPE client) { text; client.finish(); } \
+    }; static testrunner_##name testrunner_##name##_instance; }
+#endif
 
 #endif
 #endif


### PR DESCRIPTION
This commit improves mtclient results for measuring latency of
operations. For doing this, it adds a new template parameter lat to
struct kvtest_client. Existing test workloads don't introduce runtime
overhead because the parameter is in template.

For activating the latency testing, mtclient requires a newly added
option -L (--latency-test).

Example of rw4, the last 4 lines are the newly printed latencies:
tcp, w 512, test rw4, children 1
0 now getting
0 total 20201473 2059201 put/s 3914814 get/s
{"puts":20201473,"puts_per_sec":2059201.0918,"gets":20201473,"gets_per_sec":3914813.84296,"ops":40402946,"ops_per_sec":2698817.806,"get_check_key8_lat_min":0,"get_check_key8_lat_max":0.000180006027222,"put_key8_lat_min":0,"put_key8_lat_max":0.100251197815}
total 40402946
puts: n 1, total 20201473, average 20201473, min 20201473, max 20201473, stddev -nan
gets: n 1, total 20201473, average 20201473, min 20201473, max 20201473, stddev -nan
puts/s: n 1, total 2059201, average 2059201, min 2059201, max 2059201, stddev -nan
gets/s: n 1, total 3914814, average 3914814, min 3914814, max 3914814, stddev -nan
minimum get check key8 latency: 0.000000 sec
maximum get check key8 latency: 0.000180 sec
minimum put key8 latency: 0.000000 sec
maximum put key8 latency: 0.100251 sec