### PR TITLE
mtd: report status of rcu quiesce

### DIFF
--- a/log.cc
+++ b/log.cc
@@ -43,6 +43,8 @@ kvepoch_t rec_replay_min_epoch;
 kvepoch_t rec_replay_max_epoch;
 kvepoch_t rec_replay_min_quiescent_last_epoch;
 
+extern bool enable_quiesce_stat;
+
 struct logrec_base {
     uint32_t command_;
     uint32_t size_;
@@ -209,7 +211,7 @@ void loginfo::initialize(const String& logfile) {
     f_.filename_ = logfile.internal_rep();
     f_.filename_.ref();
 
-    ti_ = threadinfo::make(threadinfo::TI_LOG, logindex_);
+    ti_ = threadinfo::make(threadinfo::TI_LOG, logindex_, enable_quiesce_stat);
     int r = ti_->run(logger_trampoline, this);
     always_assert(r == 0);
 }

--- a/mttest.cc
+++ b/mttest.cc
@@ -661,7 +661,7 @@ static struct {
 void runtest(int nthreads, void* (*func)(threadinfo*)) {
     std::vector<threadinfo *> tis;
     for (int i = 0; i < nthreads; ++i)
-        tis.push_back(threadinfo::make(threadinfo::TI_PROCESS, i));
+	tis.push_back(threadinfo::make(threadinfo::TI_PROCESS, i, false));
     signal(SIGALRM, test_timeout);
     for (int i = 0; i < nthreads; ++i) {
         int r = tis[i]->run(func);
@@ -1021,7 +1021,7 @@ Try 'mttest --help' for options.\n");
 }
 
 static void run_one_test_body(int trial, const char *treetype, const char *test) {
-    threadinfo *main_ti = threadinfo::make(threadinfo::TI_MAIN, -1);
+    threadinfo *main_ti = threadinfo::make(threadinfo::TI_MAIN, -1, false);
     main_ti->run();
     globalepoch = timestamp() >> 16;
     for (int i = 0; i < (int) arraysize(test_thread_map); ++i)


### PR DESCRIPTION
This commit adds a new option -q to mtd. If -q is passed, mtd reports
status (including a number of freed objects, duration) of rcu quiesce
of each thread when it exits.

Below is an example output:
...
joining thread log:3
joining thread log:2
joining thread log:1
joining thread log:0
  heights:  7=16021562  8=17229535
  node counts:  1=1  2=3782161  3=1730080  4=704425  5=230478  6=62749  7=26948  8=531155  9=370800  10=321941  11=286366  12=252442  13=217998  14=180955  15=149874
quiesce stat of thread 7f8be2ffd700 (index: 3, thread type: process)
a number of minimum freed limbo objects: 0
a number of maximum freed limbo objects: 200
minimum duration: 0.000000
maximum duration: 0.000138
quiesce stat of thread 7f8be37fe700 (index: 2, thread type: process)
a number of minimum freed limbo objects: 0
a number of maximum freed limbo objects: 190
minimum duration: 0.000000
maximum duration: 0.000137
quiesce stat of thread 7f8be3fff700 (index: 1, thread type: process)
a number of minimum freed limbo objects: 0
a number of maximum freed limbo objects: 2
minimum duration: 0.000000
maximum duration: 0.004996
quiesce stat of thread 7f8bf0937700 (index: 0, thread type: process)
a number of minimum freed limbo objects: 1
a number of maximum freed limbo objects: 2
minimum duration: 0.000000
maximum duration: 0.015530