### PR TITLE
mtd: asynchronous rcu quiesce for reducing latency

### DIFF
--- a/log.cc
+++ b/log.cc
@@ -209,7 +209,7 @@ void loginfo::initialize(const String& logfile) {
     f_.filename_ = logfile.internal_rep();
     f_.filename_.ref();
 
-    ti_ = threadinfo::make(threadinfo::TI_LOG, logindex_);
+    ti_ = threadinfo::make(threadinfo::TI_LOG, logindex_, false);
     int r = ti_->run(logger_trampoline, this);
     always_assert(r == 0);
 }

--- a/mttest.cc
+++ b/mttest.cc
@@ -662,7 +662,7 @@ static struct {
 void runtest(int nthreads, void* (*func)(threadinfo*)) {
     std::vector<threadinfo *> tis;
     for (int i = 0; i < nthreads; ++i)
-        tis.push_back(threadinfo::make(threadinfo::TI_PROCESS, i));
+        tis.push_back(threadinfo::make(threadinfo::TI_PROCESS, i, false));
     signal(SIGALRM, test_timeout);
     for (int i = 0; i < nthreads; ++i) {
         int r = tis[i]->run(func);
@@ -1022,7 +1022,7 @@ Try 'mttest --help' for options.\n");
 }
 
 static void run_one_test_body(int trial, const char *treetype, const char *test) {
-    threadinfo *main_ti = threadinfo::make(threadinfo::TI_MAIN, -1);
+    threadinfo *main_ti = threadinfo::make(threadinfo::TI_MAIN, -1, false);
     main_ti->run();
     globalepoch = timestamp() >> 16;
     for (int i = 0; i < (int) arraysize(test_thread_map); ++i)


### PR DESCRIPTION
This commit adds a new option --async-quiesce to mtd. This option
enables asynchronous rcu quiesce for reducing request latency. The
strategy is very simple: a thread collects garbage objects of its
limbo list (which can be simply free()ed, not returned into
threadinfo.pool_) in a vector and passes to a thread that only does
reclamation.