### PR TITLE
Change error message to suggest using CXXFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,8 +127,8 @@ if test "$ac_cv_cxx_auto" != yes; then
     AC_MSG_ERROR([
 
 The C++ compiler does not appear to understand C++11.
-To fix this problem, try supplying a "CXX" argument to ./configure,
-such as "./configure CXX='c++ -std=gnu++0x'".
+Try supplying a CXXFLAGS argument to ./configure,
+such as "./configure CXXFLAGS='-std=gnu++0x'".
 
 ========================================================])
 fi


### PR DESCRIPTION
The existing error message suggested adding a flag to CXX. It's probably
cleaner and more standard to use CXXFLAGS, and it lets the C++ compiler
be specified separately.