### PR TITLE
kvthread: fix an assertion violation caused by RCU reclamation

### DIFF
--- a/kvthread.hh
+++ b/kvthread.hh
@@ -132,6 +132,10 @@ class threadinfo {
         if (has_threadcounter<int(ncounters)>::test(ci))
             counters_[ci] += delta;
     }
+    void unmark(threadcounter ci, int64_t delta) {
+        if (has_threadcounter<int(ncounters)>::test(ci))
+            counters_[ci] -= delta;
+    }
     bool has_counter(threadcounter ci) const {
         return has_threadcounter<int(ncounters)>::test(ci);
     }


### PR DESCRIPTION

Current RCU reclamation can cause an assertion violation like below:
```
mtd: kvthread.cc:68: void threadinfo::refill_rcu(): Assertion `limbo_tail_->head_ == 0 && limbo_tail_->tail_ == 0' failed.
```

This commit fixes it.