### PR TITLE
mtd: stop RCU quiesce state after serializing a result of a request

### DIFF
--- a/mtd.cc
+++ b/mtd.cc
@@ -1156,8 +1156,8 @@ void* tcp_threadfunc(void* x) {
                     goto closed;
                 ti->rcu_start();
                 ret = onego(q, request, c->recent_string(xposition), *ti);
-                ti->rcu_stop();
                 msgpack::unparse(*c->kvout, request);
+                ti->rcu_stop();
                 request.clear();
                 if (likely(ret >= 0)) {
                     if (c->check(0))


### PR DESCRIPTION
Current mtd calls ti->rcu_stop() before serializing a result of a
request. However, IIUC, the result, e.g. read value of get request, is
managed under RCU and is not deep copied for the thread. So calling
ti->rcu_stop() will give a chance of collecting a value that can be
contained by the result to other threads. It would result a situation
that a request processing thread can read stale pointers.

This commit swaps an order of ti->rcu_stop() and result serialization
for avoid the problem.