### PR TITLE
Use `rm` from PATH for libjson.a rule in Makefile

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -33,7 +33,7 @@ all: test_atomics mtd mtclient mttest
 
 libjson.a: json.o string.o straccum.o str.o msgpack.o \
 	clp.o kvrandom.o compiler.o memdebug.o kvthread.o
-	@/bin/rm -f $@
+	@rm -f $@
 	$(AR) cru $@ $^
 
 KVTREES = query_masstree.o \


### PR DESCRIPTION
NixOS doesn’t use `/bin/` for executables, but _does_ maintain standard shell utilities in the PATH. It’s a pretty niche problem, but replacing `/bin/rm` with just regular old `rm` in one Makefile rule seems otherwise harmless.